### PR TITLE
Improve sound overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ You can see it in action at: https://imgntn.github.io/jBow/?avatar-recording=rec
 3.0
 - [] after pickup the rotation of the bow should be controlled by the line between the hands, not the controller rotation at all. followed by a short slerp back to real controller rotation after firing.  ala the lab
 - [] arrow is not hitting 'static-body' target obj.  does hit primitive box, so its not a lack of CCD (continuous collision detection)
-- [] increase poolsize for sounds to allow them to overlap
+- [x] increase poolsize for sounds to allow them to overlap
 - [] how to better see the arrow during flight -- glow, particle trail?
 - [] make arrow stick and then add cooldown delay before disappearing them
-- [] visual indicator of target hit.  
+- [] visual indicator of target hit.
 - [] animated targets (and their phyiscs bodies)
 - [] haptic pulse on bow grab (working yet in FF/Chrome?)
 

--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
     </a-assets>
 
     <!-- Sounds -->
-    <a-sound id="arrow_release_sound" src="#arrow_release"  poolsize="4"></a-sound>
-    <a-sound id="arrow_impact_sound"  src="#arrow_impact" poolsize="4"></a-sound>
-    <a-sound id="draw_string_sound"  src="#draw_string" poolsize="4"></a-sound>
+    <a-sound id="arrow_release_sound" src="#arrow_release"  poolsize="8"></a-sound>
+    <a-sound id="arrow_impact_sound"  src="#arrow_impact" poolsize="8"></a-sound>
+    <a-sound id="draw_string_sound"  src="#draw_string" poolsize="8"></a-sound>
     
     <!-- Camera -->
     <a-entity camera look-controls></a-entity>


### PR DESCRIPTION
## Summary
- increase A-Frame sound poolsize so effects can overlap
- update README TODO checklist for sound poolsize item

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844e710e034832891f9637cb36fe70d