### PR TITLE
Implement arrow effects and target feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ You can see it in action at: https://imgntn.github.io/jBow/?avatar-recording=rec
 - [] after pickup the rotation of the bow should be controlled by the line between the hands, not the controller rotation at all. followed by a short slerp back to real controller rotation after firing.  ala the lab
 - [] arrow is not hitting 'static-body' target obj.  does hit primitive box, so its not a lack of CCD (continuous collision detection)
 - [x] increase poolsize for sounds to allow them to overlap
-- [] how to better see the arrow during flight -- glow, particle trail?
-- [] make arrow stick and then add cooldown delay before disappearing them
-- [] visual indicator of target hit.
+- [x] how to better see the arrow during flight -- glow, particle trail?
+- [x] make arrow stick and then add cooldown delay before disappearing them
+- [x] visual indicator of target hit.
 - [] animated targets (and their phyiscs bodies)
 - [] haptic pulse on bow grab (working yet in FF/Chrome?)
 

--- a/components/bow-and-arrow.js
+++ b/components/bow-and-arrow.js
@@ -32,6 +32,7 @@ AFRAME.registerComponent('bow-and-arrow', {
     this.shotMultiplier = 85;
     this.cooldown = 500;
     this.lastShot = Date.now();
+    this.arrowStickTime = 1000;
 
     this.zeroVec = new THREE.Vector3(0, 0, 0);
     this.zeroQuat = new THREE.Quaternion(0, 0, 0, 1);
@@ -171,6 +172,7 @@ AFRAME.registerComponent('bow-and-arrow', {
     // scene.object3D.add(arrowHelper)
 
     arrow.play();
+    arrow.setAttribute('material', 'color: #FFD700; emissive: #FF4500');
 
     this.playSound('arrow_release_sound', bowPosition)
 
@@ -279,11 +281,16 @@ AFRAME.registerComponent('bow-and-arrow', {
     this.playSound('arrow_impact_sound', arrow.getAttribute('position'))
     var scene = document.getElementById('scene');
 
+    if (e.detail && e.detail.body && e.detail.body.el) {
+      e.detail.body.el.emit('arrow-hit');
+    }
 
+    var stickTime = this.arrowStickTime;
     setTimeout(function removeArrow() {
       arrow.setAttribute('didCollide', 'no');
+      arrow.removeAttribute('material');
       scene.components.pool__arrow.returnEntity(arrow);
-    }, 0)
+    }, stickTime)
 
     //console.log('Arrow has collided with body #' + e.detail.body.id);
 

--- a/components/hit-feedback.js
+++ b/components/hit-feedback.js
@@ -1,0 +1,46 @@
+/* global AFRAME */
+
+/**
+ * Simple component to provide visual feedback when hit by an arrow.
+ * Changes the material color briefly when the `arrow-hit` event is received.
+ */
+AFRAME.registerComponent('hit-feedback', {
+  schema: {
+    duration: {type: 'int', default: 200},
+    color: {type: 'color', default: '#FF0000'}
+  },
+
+  init: function () {
+    this.onHit = this.onHit.bind(this);
+    this.originalColor = null;
+  },
+
+  play: function () {
+    this.el.addEventListener('arrow-hit', this.onHit);
+  },
+
+  pause: function () {
+    this.el.removeEventListener('arrow-hit', this.onHit);
+  },
+
+  onHit: function () {
+    if (!this.originalColor) {
+      var material = this.el.getAttribute('material');
+      if (material && material.color) {
+        this.originalColor = material.color;
+      } else {
+        this.originalColor = null;
+      }
+    }
+    this.el.setAttribute('material', 'color', this.data.color);
+    var el = this.el;
+    var original = this.originalColor;
+    setTimeout(function () {
+      if (original) {
+        el.setAttribute('material', 'color', original);
+      } else {
+        el.removeAttribute('material');
+      }
+    }, this.data.duration);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <script src="components/bow-and-arrow.js"></script>
   <script src="components/rotate-toward-velocity.js"></script>
   <script src="components/poissondisc-forest.js"></script>
+  <script src="components/hit-feedback.js"></script>
 
   <script src="aframe-physics-system.v1.4.0.js"></script>
 </head>
@@ -72,9 +73,9 @@
 
      <!-- Targets-->
 
-    <a-entity class="target"  static-body scale="10 10 10" rotation="0 90 0" position = "0 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
-    <a-entity class="target"  static-body scale="10 10 10" rotation="0 90 0" position = "-2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
-    <a-entity class="target"  static-body scale="10 10 10" rotation="0 90 0" position = "2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
+    <a-entity class="target" hit-feedback static-body scale="10 10 10" rotation="0 90 0" position="0 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
+    <a-entity class="target" hit-feedback static-body scale="10 10 10" rotation="0 90 0" position="-2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
+    <a-entity class="target" hit-feedback static-body scale="10 10 10" rotation="0 90 0" position="2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
 
     <a-entity id="forest" poissondisc-forest></a-entity>
 


### PR DESCRIPTION
## Summary
- improve arrow visuals with glow
- keep arrows around briefly after impact
- emit hit event and highlight targets when struck
- document completed features in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68455adf80b08328a1202271c5fbc4b6