### PR TITLE
Improve bow aiming and target collision

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,9 @@
 
      <!-- Targets-->
 
-    <a-entity class="target" animated-target="speed:20" hit-feedback static-body scale="10 10 10" rotation="0 90 0" position="0 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
-    <a-entity class="target" animated-target="speed:20" hit-feedback static-body scale="10 10 10" rotation="0 90 0" position="-2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
-    <a-entity class="target" animated-target="speed:20" hit-feedback static-body scale="10 10 10" rotation="0 90 0" position="2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
+    <a-entity class="target" animated-target="speed:20" hit-feedback static-body="shape: box" scale="10 10 10" rotation="0 90 0" position="0 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
+    <a-entity class="target" animated-target="speed:20" hit-feedback static-body="shape: box" scale="10 10 10" rotation="0 90 0" position="-2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
+    <a-entity class="target" animated-target="speed:20" hit-feedback static-body="shape: box" scale="10 10 10" rotation="0 90 0" position="2 2 -4" obj-model="obj: #target-obj; mtl: #target-mtl"></a-entity>
 
     <a-entity id="forest" poissondisc-forest></a-entity>
 


### PR DESCRIPTION
## Summary
- disable default rotation while aiming and slerp back after firing
- compute bow orientation from positions of both hands
- fix target collision by specifying static-body shape

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684693655d608328a362677a13943c07